### PR TITLE
Use dataclass slots to decrease memory usage

### DIFF
--- a/src/genieutils/civ.py
+++ b/src/genieutils/civ.py
@@ -5,7 +5,7 @@ from genieutils.unit import Unit
 from genieutils.versions import Version
 
 
-@dataclass
+@dataclass(slots=True)
 class Civ(GenieClass):
     player_type: int
     name: str

--- a/src/genieutils/datfile.py
+++ b/src/genieutils/datfile.py
@@ -18,7 +18,7 @@ from genieutils.unitheaders import UnitHeaders
 from genieutils.versions import Version
 
 
-@dataclass
+@dataclass(slots=True)
 class DatFile(GenieClass):
     version: str
     float_ptr_terrain_tables: list[int]

--- a/src/genieutils/effect.py
+++ b/src/genieutils/effect.py
@@ -4,7 +4,7 @@ from genieutils.common import ByteHandler, GenieClass
 from genieutils.versions import Version
 
 
-@dataclass
+@dataclass(slots=True)
 class EffectCommand(GenieClass):
     type: int
     a: int
@@ -32,7 +32,7 @@ class EffectCommand(GenieClass):
         ])
 
 
-@dataclass
+@dataclass(slots=True)
 class Effect(GenieClass):
     name: str
     effect_commands: list[EffectCommand]

--- a/src/genieutils/graphic.py
+++ b/src/genieutils/graphic.py
@@ -4,7 +4,7 @@ from genieutils.common import ByteHandler, GenieClass
 from genieutils.versions import Version
 
 
-@dataclass
+@dataclass(slots=True)
 class GraphicDelta(GenieClass):
     graphic_id: int
     padding_1: int
@@ -38,7 +38,7 @@ class GraphicDelta(GenieClass):
         ])
 
 
-@dataclass
+@dataclass(slots=True)
 class GraphicAngleSound(GenieClass):
     frame_num: int
     sound_id: int
@@ -78,7 +78,7 @@ class GraphicAngleSound(GenieClass):
         ])
 
 
-@dataclass
+@dataclass(slots=True)
 class Graphic(GenieClass):
     name: str
     file_name: str

--- a/src/genieutils/playercolour.py
+++ b/src/genieutils/playercolour.py
@@ -4,7 +4,7 @@ from genieutils.common import ByteHandler, GenieClass
 from genieutils.versions import Version
 
 
-@dataclass
+@dataclass(slots=True)
 class PlayerColour(GenieClass):
     id: int
     player_color_base: int

--- a/src/genieutils/randommaps.py
+++ b/src/genieutils/randommaps.py
@@ -4,7 +4,7 @@ from genieutils.common import ByteHandler, GenieClass
 from genieutils.versions import Version
 
 
-@dataclass
+@dataclass(slots=True)
 class MapUnit(GenieClass):
     unit: int
     host_terrain: int
@@ -56,7 +56,7 @@ class MapUnit(GenieClass):
         ])
 
 
-@dataclass
+@dataclass(slots=True)
 class MapTerrain(GenieClass):
     proportion: int
     terrain: int
@@ -87,7 +87,7 @@ class MapTerrain(GenieClass):
         ])
 
 
-@dataclass
+@dataclass(slots=True)
 class MapLand(GenieClass):
     land_id: int
     terrain: int
@@ -145,7 +145,7 @@ class MapLand(GenieClass):
         ])
 
 
-@dataclass
+@dataclass(slots=True)
 class MapElevation(GenieClass):
     proportion: int
     terrain: int
@@ -176,7 +176,7 @@ class MapElevation(GenieClass):
         ])
 
 
-@dataclass
+@dataclass(slots=True)
 class MapInfo(GenieClass):
     map_id: int
     border_south_west: int
@@ -277,7 +277,7 @@ class MapInfo(GenieClass):
         ])
 
 
-@dataclass
+@dataclass(slots=True)
 class RandomMaps(GenieClass):
     random_maps_ptr: int
     map_info_1: list[MapInfo]

--- a/src/genieutils/sound.py
+++ b/src/genieutils/sound.py
@@ -4,7 +4,7 @@ from genieutils.common import ByteHandler, GenieClass
 from genieutils.versions import Version
 
 
-@dataclass
+@dataclass(slots=True)
 class SoundItem(GenieClass):
     filename: str
     resource_id: int
@@ -32,7 +32,7 @@ class SoundItem(GenieClass):
         ])
 
 
-@dataclass
+@dataclass(slots=True)
 class Sound(GenieClass):
     id: int
     play_delay: int

--- a/src/genieutils/task.py
+++ b/src/genieutils/task.py
@@ -4,7 +4,7 @@ from genieutils.common import ByteHandler, GenieClass
 from genieutils.versions import Version
 
 
-@dataclass
+@dataclass(slots=True)
 class Task(GenieClass):
     task_type: int
     id: int

--- a/src/genieutils/tech.py
+++ b/src/genieutils/tech.py
@@ -4,7 +4,7 @@ from genieutils.common import ByteHandler, GenieClass
 from genieutils.versions import Version
 
 
-@dataclass
+@dataclass(slots=True)
 class ResearchResourceCost(GenieClass):
     type: int
     amount: int
@@ -26,7 +26,7 @@ class ResearchResourceCost(GenieClass):
         ])
 
 
-@dataclass
+@dataclass(slots=True)
 class Tech(GenieClass):
     required_techs: tuple[int, int, int, int, int, int]
     resource_costs: tuple[ResearchResourceCost, ResearchResourceCost, ResearchResourceCost]

--- a/src/genieutils/techtree.py
+++ b/src/genieutils/techtree.py
@@ -4,7 +4,7 @@ from genieutils.common import ByteHandler, GenieClass
 from genieutils.versions import Version
 
 
-@dataclass
+@dataclass(slots=True)
 class Common(GenieClass):
     slots_used: int
     unit_research: tuple[int, int, int, int, int, int, int, int, int, int]
@@ -26,7 +26,7 @@ class Common(GenieClass):
         ])
 
 
-@dataclass
+@dataclass(slots=True)
 class TechTreeAge(GenieClass):
     id: int
     status: int
@@ -89,7 +89,7 @@ class TechTreeAge(GenieClass):
         ])
 
 
-@dataclass
+@dataclass(slots=True)
 class BuildingConnection(GenieClass):
     id: int
     status: int
@@ -152,7 +152,7 @@ class BuildingConnection(GenieClass):
         ])
 
 
-@dataclass
+@dataclass(slots=True)
 class UnitConnection(GenieClass):
     id: int
     status: int
@@ -207,7 +207,7 @@ class UnitConnection(GenieClass):
         ])
 
 
-@dataclass
+@dataclass(slots=True)
 class ResearchConnection(GenieClass):
     id: int
     status: int
@@ -266,7 +266,7 @@ class ResearchConnection(GenieClass):
         ])
 
 
-@dataclass
+@dataclass(slots=True)
 class TechTree(GenieClass):
     total_unit_tech_groups: int
     tech_tree_ages: list[TechTreeAge]

--- a/src/genieutils/terrainblock.py
+++ b/src/genieutils/terrainblock.py
@@ -4,7 +4,7 @@ from genieutils.common import ByteHandler, TILE_TYPE_COUNT, TERRAIN_COUNT, Genie
 from genieutils.versions import Version
 
 
-@dataclass
+@dataclass(slots=True)
 class FrameData(GenieClass):
     frame_count: int
     angle_count: int
@@ -26,7 +26,7 @@ class FrameData(GenieClass):
         ])
 
 
-@dataclass
+@dataclass(slots=True)
 class Terrain(GenieClass):
     enabled: int
     random: int
@@ -153,7 +153,7 @@ class Terrain(GenieClass):
         ])
 
 
-@dataclass
+@dataclass(slots=True)
 class TileSize(GenieClass):
     width: int
     height: int
@@ -175,7 +175,7 @@ class TileSize(GenieClass):
         ])
 
 
-@dataclass
+@dataclass(slots=True)
 class TerrainBlock(GenieClass):
     virtual_function_ptr: int
     map_pointer: int

--- a/src/genieutils/terrainrestriction.py
+++ b/src/genieutils/terrainrestriction.py
@@ -4,7 +4,7 @@ from genieutils.common import ByteHandler, GenieClass
 from genieutils.versions import Version
 
 
-@dataclass
+@dataclass(slots=True)
 class TerrainPassGraphic(GenieClass):
     exit_tile_sprite_id: int
     enter_tile_sprite_id: int
@@ -29,7 +29,7 @@ class TerrainPassGraphic(GenieClass):
         ])
 
 
-@dataclass
+@dataclass(slots=True)
 class TerrainRestriction(GenieClass):
     passable_buildable_dmg_multiplier: list[float]
     terrain_pass_graphics: list[TerrainPassGraphic]

--- a/src/genieutils/unit.py
+++ b/src/genieutils/unit.py
@@ -5,7 +5,7 @@ from genieutils.task import Task
 from genieutils.versions import Version
 
 
-@dataclass
+@dataclass(slots=True)
 class ResourceStorage(GenieClass):
     type: int
     amount: float
@@ -27,7 +27,7 @@ class ResourceStorage(GenieClass):
         ])
 
 
-@dataclass
+@dataclass(slots=True)
 class DamageGraphic(GenieClass):
     graphic_id: int
     damage_percent: int
@@ -49,7 +49,7 @@ class DamageGraphic(GenieClass):
         ])
 
 
-@dataclass
+@dataclass(slots=True)
 class DeadFish(GenieClass):
     walking_graphic: int
     running_graphic: int
@@ -104,7 +104,7 @@ class DeadFish(GenieClass):
         ])
 
 
-@dataclass
+@dataclass(slots=True)
 class Bird(GenieClass):
     default_task_id: int
     search_radius: float
@@ -167,7 +167,7 @@ class Bird(GenieClass):
         ])
 
 
-@dataclass
+@dataclass(slots=True)
 class AttackOrArmor(GenieClass):
     class_: int
     amount: int
@@ -186,7 +186,7 @@ class AttackOrArmor(GenieClass):
         ])
 
 
-@dataclass
+@dataclass(slots=True)
 class Type50(GenieClass):
     base_armor: int
     attacks: list[AttackOrArmor]
@@ -291,7 +291,7 @@ class Type50(GenieClass):
         ])
 
 
-@dataclass
+@dataclass(slots=True)
 class Projectile(GenieClass):
     projectile_type: int
     smart_mode: int
@@ -322,7 +322,7 @@ class Projectile(GenieClass):
         ])
 
 
-@dataclass
+@dataclass(slots=True)
 class ResourceCost(GenieClass):
     type: int
     amount: int
@@ -344,7 +344,7 @@ class ResourceCost(GenieClass):
         ])
 
 
-@dataclass
+@dataclass(slots=True)
 class Creatable(GenieClass):
     resource_costs: tuple[ResourceCost, ResourceCost, ResourceCost]
     train_time: int
@@ -435,7 +435,7 @@ class Creatable(GenieClass):
         ])
 
 
-@dataclass
+@dataclass(slots=True)
 class BuildingAnnex(GenieClass):
     unit_id: int
     misplacement_x: float
@@ -457,7 +457,7 @@ class BuildingAnnex(GenieClass):
         ])
 
 
-@dataclass
+@dataclass(slots=True)
 class Building(GenieClass):
     construction_graphic_id: int
     snow_graphic_id: int
@@ -548,7 +548,7 @@ class Building(GenieClass):
         ])
 
 
-@dataclass
+@dataclass(slots=True)
 class Unit(GenieClass):
     type: int
     id: int

--- a/src/genieutils/unitheaders.py
+++ b/src/genieutils/unitheaders.py
@@ -5,14 +5,13 @@ from genieutils.task import Task
 from genieutils.versions import Version
 
 
-@dataclass
+@dataclass(slots=True)
 class UnitHeaders(GenieClass):
     exists: int
     task_list: list[Task] | None = None
 
     @classmethod
     def from_bytes(cls, content: ByteHandler) -> 'UnitHeaders':
-        super().__init__(content)
         exists = content.read_int_8()
         task_list = None
         if exists:

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -101,7 +101,7 @@ class TestByteHandler:
     
     @pytest.fixture
     def child_genie_class(self):
-        @dataclasses.dataclass
+        @dataclasses.dataclass(slots=True)
         class ChildGenieClass(GenieClass):
             int_8_val: int
             int_16_val: int


### PR DESCRIPTION
This PR adds the use of slots to the dataclasses which greatly reduces memory usage. From my basic test I see a about a 45% reduction in usage. The runtime is potentially slightly worse but those results are far less reliable as I had a lot of other stuff running on the system and there might be caching effects etc.

This change also removes the
```python
super().__init__(content)
``` 

call in unitheaders.py. There seem to be no reason for that call to be there. If it needs to be there, it needs to be re-written, see the [dataclass docs](https://docs.python.org/3/library/dataclasses.html#:~:text=Warning%20Calling%20no%2Darg%20super()%20in%20dataclasses%20using%20slots%3DTrue%20will%20result%20in%20the%20following%20exception%20being%20raised%3A%20TypeError%3A%20super(type%2C%20obj)%3A%20obj%20must%20be%20an%20instance%20or%20subtype%20of%20type.%20The%20two%2Darg%20super()%20is%20a%20valid%20workaround.%20See%20gh%2D90562%20for%20full%20details.)

Test script:
```python
#!/usr/bin/env python3

import sys
sys.path.insert(1, '../genieutils-py/src')
from genieutils.datfile import DatFile
DatFile.parse('empires2_x2_p1.dat')
```

## Memory Usage

Before changes:
```
python -m memory_profiler test1.py 
Filename: /home/zetatwo/Projects/genieutils-py-test/../genieutils-py/src/genieutils/datfile.py

Line #    Mem usage    Increment  Occurrences   Line Contents
=============================================================
    45   24.324 MiB   24.324 MiB           1       @classmethod
    46                                             @profile
    47                                             def parse(cls, input_file: Path | PathLike | str) -> 'DatFile':
    48   31.574 MiB    7.250 MiB           1           content = Path(input_file).read_bytes()
    49   92.594 MiB   61.020 MiB           1           data = zlib.decompress(content, wbits=-15)
    50   92.594 MiB    0.000 MiB           1           byte_handler = ByteHandler(memoryview(data))
    51 1287.094 MiB 1194.500 MiB           1           return cls.from_bytes(byte_handler)
```

After changes:
```
python -m memory_profiler test1.py
Filename: /home/zetatwo/Projects/genieutils-py-test/../genieutils-py/src/genieutils/datfile.py

Line #    Mem usage    Increment  Occurrences   Line Contents
=============================================================
    45   24.500 MiB   24.500 MiB           1       @classmethod
    46                                             @profile
    47                                             def parse(cls, input_file: Path | PathLike | str) -> 'DatFile':
    48   31.750 MiB    7.250 MiB           1           content = Path(input_file).read_bytes()
    49   92.762 MiB   61.012 MiB           1           data = zlib.decompress(content, wbits=-15)
    50   92.762 MiB    0.000 MiB           1           byte_handler = ByteHandler(memoryview(data))
    51  703.137 MiB  610.375 MiB           1           return cls.from_bytes(byte_handler)
```

## Run Time

Before changes:
```
time python3 test1.py        
python3 test1.py  12.29s user 9.12s system 98% cpu 21.666 total
time python3 test1.py
python3 test1.py  18.51s user 0.78s system 100% cpu 19.107 total
time python3 test1.py
python3 test1.py  16.24s user 0.62s system 100% cpu 16.703 total


```

After changes:
```
time python3 test1.py
python3 test1.py  16.94s user 0.39s system 100% cpu 17.161 total
time python3 test1.py
python3 test1.py  17.13s user 0.44s system 98% cpu 17.806 total
time python3 test1.py
python3 test1.py  21.02s user 0.48s system 98% cpu 21.869 total
```